### PR TITLE
Fix todo API base URL for ingress rewrite

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -10,7 +10,7 @@ const authApi = axios.create({
 });
 
 const todoApi = axios.create({
-  baseURL: process.env.REACT_APP_API_BASE_URL || '/api/todo',
+  baseURL: process.env.REACT_APP_API_BASE_URL || '/api',
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- update the frontend todo API client to default to `/api` so ingress rewrites requests to the backend correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd5a885810832abeb606fa69acb08e